### PR TITLE
Modification du lien officiel de ProtonMail

### DIFF
--- a/courriel/protonmail.php
+++ b/courriel/protonmail.php
@@ -106,7 +106,7 @@
                 <!-- site -->
                 <div class="btn-toolbar justify-content-center" role="toolbar" aria-label="Groupe de liens">
                   <div class="btn-group mr-2" role="group" aria-label="Site de ProtonMail">
-                    <a href="https://protonmail.com/default/fr/" target="_blank" role="button" class="btn">Site officiel <i class="fa fa-external-link" aria-hidden="true"></i></a>
+                    <a href="https://protonmail.com" target="_blank" role="button" class="btn">Site officiel <i class="fa fa-external-link" aria-hidden="true"></i></a>
                   </div>
                   <div class="btn-group" role="group" aria-label="Documentation de ProtonMail">
                     <a href="https://protonmail.com/support/" target="_blank" role="button" class="btn">Documentation <i class="fa fa-external-link" aria-hidden="true"></i></a>

--- a/courriel/protonmail.php
+++ b/courriel/protonmail.php
@@ -106,7 +106,7 @@
                 <!-- site -->
                 <div class="btn-toolbar justify-content-center" role="toolbar" aria-label="Groupe de liens">
                   <div class="btn-group mr-2" role="group" aria-label="Site de ProtonMail">
-                    <a href="https://protonmail.com" target="_blank" role="button" class="btn">Site officiel <i class="fa fa-external-link" aria-hidden="true"></i></a>
+                    <a href="https://protonmail.com/fr/" target="_blank" role="button" class="btn">Site officiel <i class="fa fa-external-link" aria-hidden="true"></i></a>
                   </div>
                   <div class="btn-group" role="group" aria-label="Documentation de ProtonMail">
                     <a href="https://protonmail.com/support/" target="_blank" role="button" class="btn">Documentation <i class="fa fa-external-link" aria-hidden="true"></i></a>


### PR DESCRIPTION
L'ancien lien vers le site officiel pointait vers une page erreur 404